### PR TITLE
feat: paginacion en la API

### DIFF
--- a/src/lib/schemas/searchSchema.ts
+++ b/src/lib/schemas/searchSchema.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
-import { DAYS_VALUES, THEME_VALUES, ZONE_VALUES } from '@/utils/consts'
+import { DAYS_VALUES, THEME_VALUES, ZONE_VALUES, MAX_PAGES } from '@/utils/consts'
 
-/** Declaración del esquema de consulta Backend */
+/** Declaración del esquema de consulta a la API */
 export const querySchema = z.object({
   zona: z.enum(ZONE_VALUES).optional(),
   tema: z.enum(THEME_VALUES).optional(),
@@ -10,7 +10,12 @@ export const querySchema = z.object({
     .transform((value) => value.split(';').map((day) => day.trim()))
     .pipe(z.enum(DAYS_VALUES).array())
     .optional(),
-  precio: z.literal('gratis').optional()
+  precio: z.literal('gratis').optional(),
+  page: z
+    .string()
+    .transform((value) => parseInt(value))
+    .pipe(z.number().int().min(1).max(MAX_PAGES))
+    .optional()
 }).strict()
 
 /** Declaración del esquema de consulta Frontend */

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -23,5 +23,5 @@ export const DAYS_VALUES = [
 ] as const
 
 export const TOTAL_MUSEUMS = data.length
-export const MAX_RESULTS = 5
+export const MAX_RESULTS = 2
 export const MAX_PAGES = Math.ceil(TOTAL_MUSEUMS / MAX_RESULTS)

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -1,3 +1,5 @@
+import { data } from '@/lib/data/test'
+
 export const ZONE_VALUES = [
   'Norte',
   'Sur',
@@ -19,3 +21,7 @@ export const DAYS_VALUES = [
   'Sabado',
   'Domingo'
 ] as const
+
+export const TOTAL_MUSEUMS = data.length
+export const MAX_RESULTS = 5
+export const MAX_PAGES = Math.ceil(TOTAL_MUSEUMS / MAX_RESULTS)


### PR DESCRIPTION
La API ahora puede recibir el parámetro 'page'
- La cantidad de resultados está en el archivo consts.ts
- El parámetro es opcional
- Si no se especifica la API retorna todos los resultados